### PR TITLE
[FEAT] 드롭다른 필드 최대 수량 변경

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
     agent any
     environment {
         REGISTRY_URL = "${env.PRIVATE_REGISTRY_URL}"
-        APP_VERSION = '1.1.0'
+        APP_VERSION = '1.1.1'
         IMAGE_NAME = 'coffeenote'
 
         REGISTRY_CRED_ID = 'private-registry-auth'

--- a/src/main/kotlin/com/gabinote/coffeenote/field/domain/fieldType/type/ListSelectFieldType.kt
+++ b/src/main/kotlin/com/gabinote/coffeenote/field/domain/fieldType/type/ListSelectFieldType.kt
@@ -34,9 +34,9 @@ abstract class ListSelectFieldType : FieldType() {
                         message = "At least two options are required. if you want to have only one option, use a Toggle field instead."
                     )
 
-                    value.size > 100 -> FieldTypeValidationResult(
+                    value.size > 200 -> FieldTypeValidationResult(
                         valid = false,
-                        message = "Maximum number of options is 100."
+                        message = "Maximum number of options is 200."
                     )
 
                     value.any { it.isEmpty() } -> FieldTypeValidationResult(

--- a/src/main/kotlin/com/gabinote/coffeenote/field/domain/fieldType/type/MultiSelectFieldType.kt
+++ b/src/main/kotlin/com/gabinote/coffeenote/field/domain/fieldType/type/MultiSelectFieldType.kt
@@ -23,7 +23,7 @@ class MultiSelectFieldType : ListSelectFieldType() {
      * true: 표시 가능, false: 표시 불가
      */
     override val canDisplay: Boolean = true
-    override val isExcludeIndexing: Boolean = true
+    override val isExcludeIndexing: Boolean = false
 
     /**
      * 다중 선택 필드 값의 유효성 검사를 수행

--- a/src/main/kotlin/com/gabinote/coffeenote/field/dto/attribute/controller/AttributeCreateReqControllerDto.kt
+++ b/src/main/kotlin/com/gabinote/coffeenote/field/dto/attribute/controller/AttributeCreateReqControllerDto.kt
@@ -23,9 +23,9 @@ data class AttributeCreateReqControllerDto(
 
     /**
      * 속성 값 집합
-     * 각 값은 최대 50자까지 허용되며 전체 집합은 최대 100개 요소까지 허용
+     * 각 값은 최대 50자까지 허용되며 전체 집합은 최대 200개 요소까지 허용
      */
     @field:CollectionElementLength(length = 50, resourceName = "attribute value")
-    @field:Size(max = 100, message = "value must be at most 100")
-    val value: Set<String> = setOf()
+    @field:Size(max = 200, message = "value must be at most 200")
+    val value: Set<String> = setOf(),
 )

--- a/src/main/kotlin/com/gabinote/coffeenote/field/dto/attribute/controller/AttributeUpdateReqControllerDto.kt
+++ b/src/main/kotlin/com/gabinote/coffeenote/field/dto/attribute/controller/AttributeUpdateReqControllerDto.kt
@@ -23,9 +23,9 @@ data class AttributeUpdateReqControllerDto(
 
     /**
      * 속성 값 집합
-     * 각 값은 최대 50자까지 허용되며 전체 집합은 최대 100개 요소까지 허용
+     * 각 값은 최대 50자까지 허용되며 전체 집합은 최대 200개 요소까지 허용
      */
     @field:CollectionElementLength(length = 50, resourceName = "attribute value")
-    @field:Size(max = 100, message = "value must be at most 100")
-    val value: Set<String>
+    @field:Size(max = 200, message = "value must be at most 200")
+    val value: Set<String>,
 )

--- a/src/test/kotlin/com/gabinote/coffeenote/field/domain/fieldType/DropDownFieldTypeTest.kt
+++ b/src/test/kotlin/com/gabinote/coffeenote/field/domain/fieldType/DropDownFieldTypeTest.kt
@@ -101,11 +101,11 @@ class DropDownFieldTypeTest : MockkTestTemplate() {
                             setOf(
                                 Attribute(
                                     key = "values",
-                                    value = TestCollectionHelper.generateRandomStringSet(maxLength = 50, count = 101)
+                                    value = TestCollectionHelper.generateRandomStringSet(maxLength = 50, count = 201)
                                 ),
                                 Attribute(key = "allowAddValue", value = setOf("true"))
                             ),
-                            "values attributes 의 value 가 100개를 초과하면"
+                            "values attributes 의 value 가 200개를 초과하면"
                         ),
                     ).forAll { invalidAttributes, reason ->
                         context(reason) {

--- a/src/test/kotlin/com/gabinote/coffeenote/field/domain/fieldType/MultiSelectFieldTypeTest.kt
+++ b/src/test/kotlin/com/gabinote/coffeenote/field/domain/fieldType/MultiSelectFieldTypeTest.kt
@@ -100,11 +100,11 @@ class MultiSelectFieldTypeTest : MockkTestTemplate() {
                             setOf(
                                 Attribute(
                                     key = "values",
-                                    value = TestCollectionHelper.generateRandomStringSet(maxLength = 50, count = 101)
+                                    value = TestCollectionHelper.generateRandomStringSet(maxLength = 50, count = 201)
                                 ),
                                 Attribute(key = "allowAddValue", value = setOf("true"))
                             ),
-                            "values attributes 의 value 가 100개를 초과하면"
+                            "values attributes 의 value 가 200개를 초과하면"
                         ),
                     ).forAll { invalidAttributes, reason ->
                         context(reason) {

--- a/src/test/kotlin/com/gabinote/coffeenote/field/web/controller/FieldAdminApiControllerTest.kt
+++ b/src/test/kotlin/com/gabinote/coffeenote/field/web/controller/FieldAdminApiControllerTest.kt
@@ -649,7 +649,28 @@ class FieldAdminApiControllerTest : FieldApiTestTemplate() {
                             "attribute.value의 원소 중 하나가 50자 초과"
                         ),
 
-                        // 10. name 필드 누락
+                        // 10. attribute.value 개수 초과 (>200)
+                        row(
+                            jsonBuilder {
+                                "name" to "validName"
+                                "icon" to "123"
+                                "type" to "TEXT"
+                                "attributes" arr {
+                                    +obj {
+                                        "key" to "test"
+                                        "value" arr {
+                                            // 201개의 값 (최대 200개)
+                                            repeat(201) { index ->
+                                                +"value$index"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "attribute.value 개수 200개 초과"
+                        ),
+
+                        // 11. name 필드 누락
                         row(
                             jsonBuilder {
                                 // "name" 생략
@@ -978,6 +999,24 @@ class FieldAdminApiControllerTest : FieldApiTestTemplate() {
                                 }
                             },
                             "attributes 내부 key 길이 초과"
+                        ),
+
+                        // 8. attribute.value 개수 초과 (>200)
+                        row(
+                            jsonBuilder {
+                                "attributes" arr {
+                                    +obj {
+                                        "key" to "test"
+                                        "value" arr {
+                                            // 201개의 값 (최대 200개)
+                                            repeat(201) { index ->
+                                                +"value$index"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "attribute.value 개수 200개 초과"
                         ),
                     ).forAll { invalidDto, reason ->
                         context("$reason 인 올바르지 않은 요청이 주어졌을 때") {

--- a/src/test/kotlin/com/gabinote/coffeenote/field/web/controller/FieldApiControllerTest.kt
+++ b/src/test/kotlin/com/gabinote/coffeenote/field/web/controller/FieldApiControllerTest.kt
@@ -39,7 +39,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import java.util.*
 
 @WebMvcTest(controllers = [FieldApiController::class])
-class FieldApiControllerTest() : FieldApiTestTemplate() {
+class FieldApiControllerTest : FieldApiTestTemplate() {
 
     @Autowired
     lateinit var mockMvc: MockMvc
@@ -756,7 +756,28 @@ class FieldApiControllerTest() : FieldApiTestTemplate() {
                             "attribute.value의 원소 중 하나가 50자 초과"
                         ),
 
-                        // 10. name 필드 누락
+                        // 10. attribute.value 개수 초과 (>200)
+                        row(
+                            jsonBuilder {
+                                "name" to "validName"
+                                "icon" to "123"
+                                "type" to "TEXT"
+                                "attributes" arr {
+                                    +obj {
+                                        "key" to "test"
+                                        "value" arr {
+                                            // 201개의 값 (최대 200개)
+                                            repeat(201) { index ->
+                                                +"value$index"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "attribute.value 개수 200개 초과"
+                        ),
+
+                        // 11. name 필드 누락
                         row(
                             jsonBuilder {
                                 // "name" 생략
@@ -1081,6 +1102,24 @@ class FieldApiControllerTest() : FieldApiTestTemplate() {
                                 }
                             },
                             "attributes 내부 key 길이 초과"
+                        ),
+
+                        // 8. attribute.value 개수 초과 (>200)
+                        row(
+                            jsonBuilder {
+                                "attributes" arr {
+                                    +obj {
+                                        "key" to "test"
+                                        "value" arr {
+                                            // 201개의 값 (최대 200개)
+                                            repeat(201) { index ->
+                                                +"value$index"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "attribute.value 개수 200개 초과"
                         ),
                     ).forAll { invalidDto, reason ->
                         context("$reason 인 올바르지 않은 요청이 주어졌을 때") {

--- a/src/test/kotlin/com/gabinote/coffeenote/template/web/controller/TemplateApiAdminControllerTest.kt
+++ b/src/test/kotlin/com/gabinote/coffeenote/template/web/controller/TemplateApiAdminControllerTest.kt
@@ -454,7 +454,8 @@ class TemplateApiAdminControllerTest : TemplateControllerTest() {
                                             +obj {
                                                 "key" to "valid-key"
                                                 "value" arr {
-                                                    repeat(101) { index ->
+                                                    // 201개의 값 (최대 200개)
+                                                    repeat(201) { index ->
                                                         +"value$index"
                                                     }
                                                 }
@@ -463,7 +464,7 @@ class TemplateApiAdminControllerTest : TemplateControllerTest() {
                                     }
                                 }
                             },
-                            "field attribute value 개수 100개 초과"
+                            "field attribute value 개수 200개 초과"
                         ),
 
                         // TemplateField 필수 필드 누락
@@ -1045,7 +1046,8 @@ class TemplateApiAdminControllerTest : TemplateControllerTest() {
                                             +obj {
                                                 "key" to "valid-key"
                                                 "value" arr {
-                                                    repeat(101) { index ->
+                                                    // 201개의 값 (최대 200개)
+                                                    repeat(201) { index ->
                                                         +"value$index"
                                                     }
                                                 }
@@ -1054,7 +1056,7 @@ class TemplateApiAdminControllerTest : TemplateControllerTest() {
                                     }
                                 }
                             },
-                            "field attribute value 개수 100개 초과"
+                            "field attribute value 개수 200개 초과"
                         ),
 
                         // TemplateField 필수 필드 누락

--- a/src/test/kotlin/com/gabinote/coffeenote/template/web/controller/TemplateApiControllerTest.kt
+++ b/src/test/kotlin/com/gabinote/coffeenote/template/web/controller/TemplateApiControllerTest.kt
@@ -1054,15 +1054,15 @@ class TemplateApiControllerTest : TemplateControllerTest() {
                                         "order" to 1
                                         "is_display" to true
                                         "attributes" arr {
-                                            // 101개의 값 (최대 100개)
-                                            repeat(101) { index ->
+                                            // 201개의 값 (최대 200개)
+                                            repeat(201) { index ->
                                                 +"value$index"
                                             }
                                         }
                                     }
                                 }
                             },
-                            "field attribute value 개수 100개 초과"
+                            "field attribute value 개수 200개 초과"
                         ),
 
                         // TemplateField 필수 필드 누락
@@ -1648,15 +1648,15 @@ class TemplateApiControllerTest : TemplateControllerTest() {
                                         "order" to 1
                                         "is_display" to true
                                         "attributes" arr {
-                                            // 101개의 값 (최대 100개)
-                                            repeat(101) { index ->
+                                            // 201개의 값 (최대 200개)
+                                            repeat(201) { index ->
                                                 +"value$index"
                                             }
                                         }
                                     }
                                 }
                             },
-                            "field attribute value 개수 100개 초과"
+                            "field attribute value 개수 200개 초과"
                         ),
 
                         // TemplateField 필수 필드 누락


### PR DESCRIPTION
기존 100개 에서 200개까지 넣을 수 있도록 변경

# 작업 종류 (Type of Change)

- [x] ✨ 기능 추가 (New feature)
- [ ] 🐛 버그 수정 (Bug fix)
- [ ] ♻️ 리팩토링 (Code refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] ⚙️ 기타 (CI, Build, etc.)

<br>

# 작업 내용 (Description)

드롭박스 필드 최대 수량 변경

단일 및 다중 드롭박스 필드의 요소 제한 100개 -> 200개로 증가

관련 테스트 및 attribute create, update dto 제약 변경 

